### PR TITLE
Add simple shopping website

### DIFF
--- a/shop/index.html
+++ b/shop/index.html
@@ -5,12 +5,23 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Simple Shop</title>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <header>
         <h1>Simple Shop</h1>
     </header>
+    <div id="login-area">
+        <div id="g_id_onload"
+             data-client_id="YOUR_GOOGLE_CLIENT_ID"
+             data-callback="handleCredentialResponse"></div>
+        <div class="g_id_signin" data-type="standard"></div>
+    </div>
+    <div id="logout-area" style="display:none;">
+        Signed in as <span id="user-name"></span>
+        <button id="signout-btn" onclick="signOut()">Sign out</button>
+    </div>
     <main>
         <section id="products"></section>
     </main>

--- a/shop/index.html
+++ b/shop/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Simple Shop</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Simple Shop</h1>
+    </header>
+    <main>
+        <section id="products"></section>
+    </main>
+    <aside id="cart">
+        <h2>Cart</h2>
+        <ul id="cart-items"></ul>
+        <p id="cart-total"></p>
+    </aside>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/shop/script.js
+++ b/shop/script.js
@@ -40,4 +40,20 @@ function renderCart() {
 
 window.addEventListener('DOMContentLoaded', () => {
     renderProducts();
+
 });
+function handleCredentialResponse(response) {
+    const payload = JSON.parse(atob(response.credential.split('.')[1]));
+    document.getElementById('user-name').textContent = payload.name || payload.email;
+    document.getElementById('login-area').style.display = 'none';
+    document.getElementById('logout-area').style.display = 'block';
+}
+
+function signOut() {
+    if (window.google && google.accounts) {
+        google.accounts.id.disableAutoSelect();
+    }
+    document.getElementById('user-name').textContent = '';
+    document.getElementById('login-area').style.display = 'block';
+    document.getElementById('logout-area').style.display = 'none';
+}

--- a/shop/script.js
+++ b/shop/script.js
@@ -1,0 +1,43 @@
+const products = [
+    { id: 1, name: 'Item A', price: 19.99 },
+    { id: 2, name: 'Item B', price: 29.99 },
+    { id: 3, name: 'Item C', price: 39.99 }
+];
+
+const cart = [];
+
+function renderProducts() {
+    const container = document.getElementById('products');
+    products.forEach(product => {
+        const div = document.createElement('div');
+        div.className = 'product';
+        div.innerHTML = `
+            <h3>${product.name}</h3>
+            <p>$${product.price.toFixed(2)}</p>
+            <button onclick="addToCart(${product.id})">Add to Cart</button>
+        `;
+        container.appendChild(div);
+    });
+}
+
+function addToCart(id) {
+    const product = products.find(p => p.id === id);
+    cart.push(product);
+    renderCart();
+}
+
+function renderCart() {
+    const list = document.getElementById('cart-items');
+    list.innerHTML = '';
+    cart.forEach(item => {
+        const li = document.createElement('li');
+        li.textContent = `${item.name} - $${item.price.toFixed(2)}`;
+        list.appendChild(li);
+    });
+    const total = cart.reduce((sum, item) => sum + item.price, 0);
+    document.getElementById('cart-total').textContent = `Total: $${total.toFixed(2)}`;
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    renderProducts();
+});

--- a/shop/style.css
+++ b/shop/style.css
@@ -1,0 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+}
+main {
+    padding: 1rem;
+}
+#products {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+.product {
+    border: 1px solid #ccc;
+    padding: 1rem;
+    width: 200px;
+}
+.product button {
+    display: block;
+    margin-top: 0.5rem;
+}
+#cart {
+    position: fixed;
+    right: 1rem;
+    top: 4rem;
+    width: 200px;
+    border: 1px solid #ccc;
+    padding: 1rem;
+    background: #f9f9f9;
+}

--- a/shop/style.css
+++ b/shop/style.css
@@ -1,11 +1,12 @@
 body {
-    font-family: Arial, sans-serif;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
     margin: 0;
     padding: 0;
+    background: #f5f5f5;
 }
 header {
-    background-color: #333;
-    color: #fff;
+    background-color: #2c3e50;
+    color: #ecf0f1;
     padding: 1rem;
     text-align: center;
 }
@@ -15,16 +16,21 @@ main {
 #products {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: 1rem;
 }
 .product {
+    background: #fff;
     border: 1px solid #ccc;
+    border-radius: 8px;
     padding: 1rem;
     width: 200px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 .product button {
     display: block;
     margin-top: 0.5rem;
+    width: 100%;
 }
 #cart {
     position: fixed;
@@ -33,5 +39,15 @@ main {
     width: 200px;
     border: 1px solid #ccc;
     padding: 1rem;
-    background: #f9f9f9;
+    background: #fff;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#login-area, #logout-area {
+    text-align: center;
+    margin: 1rem;
+}
+#signout-btn {
+    margin-top: 0.5rem;
+    padding: 0.5rem 1rem;
 }

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -1,0 +1,1 @@
+from src.memory import Memory

--- a/utils/models.py
+++ b/utils/models.py
@@ -1,0 +1,1 @@
+from src.models import OpenAIModel


### PR DESCRIPTION
## Summary
- implement a basic shopping site example with HTML/CSS/JS
- add small wrappers so tests can import Memory and OpenAIModel via `utils`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6849758f63e0832ebbff803068a7325b